### PR TITLE
Add library to city-itinerary-service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,6 @@ reqwest = { version = "0.11", features = ["json"] }
 
 [dev-dependencies]
 mockito = "0.30"
+
+[lib]
+crate-type = ["rlib", "dylib"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,9 @@
+mod handlers;
+mod models;
+mod routes;
+mod db;
+
+pub use handlers::*;
+pub use models::*;
+pub use routes::*;
+pub use db::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,7 @@
+extern crate city_itinerary_service;
+
 use salvo::prelude::*;
-mod handlers;
-mod models;
-mod routes;
-mod db;
+use city_itinerary_service::{handlers, models, routes, db};
 
 #[tokio::main]
 async fn main() {


### PR DESCRIPTION
Create a library and use it as external crate in main.rs

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/arisetyo/city-itinerary-service/pull/4?shareId=6aae1ccf-2e9c-4f6e-a08d-1fbf22f3d887).